### PR TITLE
Fix scoring logic for silent vs testify cases

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,12 @@ impl World {
                     self.agents[id2].score += 1;
                 }
                 (Action::StaysSilent, Action::Testifies) => {
-                    self.agents[id1].score += 3;
+                    // The testifying agent should receive the points
+                    self.agents[id2].score += 3;
                 }
                 (Action::Testifies, Action::StaysSilent) => {
-                    self.agents[id2].score += 3;
+                    // The testifying agent should receive the points
+                    self.agents[id1].score += 3;
                 }
                 (Action::Testifies, Action::Testifies) => {
                     self.agents[id1].score += 2;


### PR DESCRIPTION
## Summary
- correct the scoring for mismatched actions so that the testifying agent receives the points
- compile and run the program to ensure correct behaviour

## Testing
- `cargo build`
- `cargo run --quiet > /tmp/run.log && tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_6862391814908328ae8d5df2b9b72451